### PR TITLE
버전 설정 오류들

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = {
             loaders: [
                 {
                     test: /\.js$/,
-                    loader: 'babel-loader',
+                    loader: 'babel-loader',//loader 부분 생략시 오류 발생 
                     exclude: /node_modules/,
                     query: {
                         cacheDirectory: true,


### PR DESCRIPTION
1. Error: Cannot find module 'webpack-cli/bin/config-yargs'
-> 구글링을 통해서 알아보니 webpack, webpack-cli와 webpack-dev-server의 버전이 맞지 않은 경우 발생합니다.
       출처: https://smoh.tistory.com/356 [Simple is Beautiful.]

------> 결과적으로 해결 불가 

**해결 방법: 버전 문제인걸 깨닫고 강사님 블로그의 버전으로 통일 후 해결**
 